### PR TITLE
Better TCP support

### DIFF
--- a/pkg/comm/engine.go
+++ b/pkg/comm/engine.go
@@ -130,7 +130,7 @@ func (e *Engine) createEndpointForIface(iface util.NetIface, ip string) *Endpoin
 	}
 
 	// Use that endpoint to connect to server
-	targetEP := tpt.Connect(ip)
+	targetEP := tpt.Connect()
 	if targetEP == nil {
 		log.Println("[ERROR:engine] Unable to connect to endpoint")
 		return nil

--- a/pkg/comm/engine_test.go
+++ b/pkg/comm/engine_test.go
@@ -97,7 +97,7 @@ func TestBasicSendRecv(t *testing.T) {
 	}
 
 	// Use that endpoint to connect to server
-	targetEP := tpt.Connect(tcpServerURL)
+	targetEP := tpt.Connect()
 	if targetEP == nil {
 		t.Fatalf("unable to connect to endpoint")
 	}

--- a/pkg/comm/multiplex_test.go
+++ b/pkg/comm/multiplex_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Geoffroy Vallee, All rights reserved
+ * This software is licensed under a 3-clause BSD license. Please consult the
+ * LICENSE.md file distributed with the sources of this project regarding your
+ * rights to use or distribute this software.
+ */
+
+package comm
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+func doMultiplexServer(t *testing.T, nClient int) {
+	log.Println("Hello, i am the server test")
+
+	fmt.Println("All messages have been received")
+}
+
+func doMultiplexClient(t *testing.T, id string) {
+	// Each client sends a single message and then terminates, once all
+	// clients are terminated, the server is supposed to detect the
+	// closed connection and terminates as well.
+	log.Printf("Hello, i am a test client (%s)\n", id)
+}
+
+/*
+func TestTCPMultiplexing(t *testing.T) {
+	// One server using a single port; two clients
+	go doServer(t)
+
+	go doClient(t, "client1")
+	doClient(t, "client2")
+}
+*/

--- a/pkg/comm/transport.go
+++ b/pkg/comm/transport.go
@@ -255,7 +255,7 @@ func (t *Transport) Recv() []byte {
 
 // Connect to a specific remote node identified by an identifier.
 // For example, the id can be a TCP address.
-func (tpt *Transport) Connect(id string) *Endpoint {
+func (tpt *Transport) Connect() *Endpoint {
 	if tpt == nil || tpt.commEngine == nil {
 		log.Println("[ERROR:transport] corrupted transport")
 		return nil
@@ -269,7 +269,7 @@ func (tpt *Transport) Connect(id string) *Endpoint {
 
 		// Add the transport to the endpoint
 		ep.transports = append(ep.transports, *tpt)
-		serverID, err := tpt.TCP.Connect(ep.ID, id)
+		serverID, err := tpt.TCP.Connect(ep.ID)
 		tpt.eps[serverID] = ep
 		if err != nil {
 			log.Printf("[ERROR:transport] unable to connect to remote peer: %s", err)

--- a/pkg/transport/tcp_test.go
+++ b/pkg/transport/tcp_test.go
@@ -14,6 +14,8 @@ const (
 
 func doServer(t *testing.T) {
 	log.Println("Hello, i am the server test")
+
+	// Server's info
 	cfg := TCPTransportCfg{
 		Interface: "127.0.0.1",
 		PortLow:   44444,
@@ -68,6 +70,8 @@ func doServer(t *testing.T) {
 func doClient(t *testing.T) {
 	id := clientID
 	log.Printf("(%s) Hello, i am a test client\n", id)
+
+	// Data about the peer we want to connect to
 	cfg := TCPTransportCfg{
 		Interface: "127.0.0.1",
 		PortLow:   44444,
@@ -79,7 +83,7 @@ func doClient(t *testing.T) {
 	}
 
 	log.Printf("(%s) Connecting to server...", id)
-	serverID, err := tcp.Connect(clientID, "127.0.0.1")
+	serverID, err := tcp.Connect(clientID)
 	if err != nil {
 		t.Fatalf("connect failed: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Geoffroy Vallee <geoffroy.vallee@gmail.com>

Better TCP support: do not required the explicit IP for connection (the IP is available from the transport); make sure we do not try to connect to ourselves in the context of a TCP transport
